### PR TITLE
restore verb queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ secrets/
 keys/
 *.tsbuildinfo
 helm/values
+node_modules

--- a/app/models/statements.ts
+++ b/app/models/statements.ts
@@ -10,22 +10,22 @@ import {
 import * as agentModel from './agent';
 
 export type QueryParams = {
-  id: string;
-  agent: Agent | Group | Activity | string;
-  verb: string;
-  activity: Agent | Group | Activity | StatementRef | Statement | string;
-  context: {
+  id?: string;
+  agent?: Agent | Group | Activity | string;
+  verb?: string;
+  activity?: Agent | Group | Activity | StatementRef | Statement | string;
+  context?: {
     registration: string;
   };
-  timestamp: any;
+  timestamp?: any;
 }
 
 export type QueryOptions = {
   params: QueryParams;
-  limit: number;
-  sort: {[key:string]: string};
-  attachments: Array<string>;
-  format: string;
+  limit?: number;
+  sort?: {[key:string]: string};
+  attachments?: Array<string>;
+  format?: string;
 }
 
 export type StatementSelect = Prisma.PromiseReturnType<typeof getByIDs>;
@@ -84,6 +84,9 @@ async function buildQueryObj (options: QueryOptions) {
     queryObj.where["context"] = {
       registration: queryObj.context.registration
     };
+  }
+  if (params.verb) {
+    queryObj.where["verbId"] = params.verb
   }
   if (params.timestamp) {
     queryObj.where["stored"] = params.timestamp;

--- a/app/test/pages/api/xAPI/statements/index.spec.ts
+++ b/app/test/pages/api/xAPI/statements/index.spec.ts
@@ -212,6 +212,27 @@ describe("[GET] /pages/api/statements", () => {
       });
   })
 
+  it("returns 200 and statements with the matching verb", async () => {
+    await testServer(handlers)
+      .post("/")
+      .auth(usr, pw)
+      .send(statementCollection.statements)
+      .expect(200);
+    await testServer(handlers)
+      .get("/")
+      .auth(usr, pw)
+      .query({verb: "http://adlnet.gov/expapi/verbs/answered"})
+      .expect(200)
+      .expect(res => {
+        delete res.body.statements[0].stored
+        delete res.body.statements[0].id
+      })
+      .expect({
+        statements: [statementCollection.statements[3]],
+        more: ""
+      });
+  })
+
   it("returns 200 and exactly two statements", async () => {
     await testServer(handlers)
       .post("/")


### PR DESCRIPTION
restore the ability to filter `statements` endpoint by verb