### PR TITLE
remove test directory from tsconfig

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -25,7 +25,8 @@
     "synchronousWatchDirectory": true,
     "excludeDirectories": [
       "**/node_modules",
-      ".next"
+      ".next",
+      "app/test"
     ]
   },
   "include": [
@@ -34,6 +35,7 @@
     "**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "app/test"
   ]
 }


### PR DESCRIPTION
production build failing due to errors in test files that don't need to be compiled for production environment